### PR TITLE
hide scrollbar in settings auth tab

### DIFF
--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/auth/auth.css
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/auth/auth.css
@@ -1,5 +1,5 @@
 .container {
-	padding: 3rem;
+	padding: 2.85rem;
 }
 
 .button .custom-icon {


### PR DESCRIPTION
lowered padding from 3 to 2.85 so its just small enough to not show the scrollbar (without error text)