### PR TITLE
Refactor calculation of non imported items for the import all button

### DIFF
--- a/editorextensions/codebeamer-custom-ui/modal/src/api/lucidGateway.ts
+++ b/editorextensions/codebeamer-custom-ui/modal/src/api/lucidGateway.ts
@@ -208,6 +208,7 @@ export class LucidGateway {
 			// 	item.tracker.keyName
 			// ),
 			codebeamerItemId: item.id,
+			codebeamerTrackerId: item.tracker.id,
 			title: item.name,
 			description: description,
 			coordinates: coordinates,

--- a/editorextensions/codebeamer-custom-ui/modal/src/hooks/useImportedItems.ts
+++ b/editorextensions/codebeamer-custom-ui/modal/src/hooks/useImportedItems.ts
@@ -23,9 +23,11 @@ export const useImportedItems = () => {
 				(x: {
 					cardBlock: { id: string };
 					codebeamerItemId: number;
+					codebeamerTrackerId: number;
 				}) => ({
 					cardBlockId: x.cardBlock.id,
 					itemId: x.codebeamerItemId,
+					trackerId: x.codebeamerTrackerId,
 				})
 			);
 			setImportedCardBlocks(cardBlockCodebeamerItemIdPairs);

--- a/editorextensions/codebeamer-custom-ui/modal/src/models/cardBlockToItemMapping.if.ts
+++ b/editorextensions/codebeamer-custom-ui/modal/src/models/cardBlockToItemMapping.if.ts
@@ -4,4 +4,5 @@
 export interface CardBlockToItemMapping {
 	cardBlockId: string;
 	itemId: number;
+	trackerId: number;
 }

--- a/editorextensions/codebeamer-custom-ui/modal/src/models/lucidCardData.ts
+++ b/editorextensions/codebeamer-custom-ui/modal/src/models/lucidCardData.ts
@@ -3,6 +3,7 @@
  */
 export interface CardData {
 	codebeamerItemId: number;
+	codebeamerTrackerId: number;
 	title?: string;
 	description?: string;
 	assignee?: string;

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/QueryResults.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/QueryResults.tsx
@@ -243,7 +243,7 @@ export default function QueryResults() {
 					onSync={handleSync}
 					importedItemsCount={importedItems.length}
 					unImportedItemsCount={
-						(data?.total ?? 0) -
+						(data?.items.length ?? 0) -
 						(data?.items.filter((i) =>
 							importedItems.find(
 								(imported) => imported.itemId == i.id

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/QueryResults.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/QueryResults.tsx
@@ -243,12 +243,15 @@ export default function QueryResults() {
 					onSync={handleSync}
 					importedItemsCount={importedItems.length}
 					unImportedItemsCount={
-						(data?.items.length ?? 0) -
-						(data?.items.filter((i) =>
-							importedItems.find(
-								(imported) => imported.itemId == i.id
-							)
-						).length ?? 0)
+						(data?.total ?? 0) -
+						(importedItems.filter((item, index, array) => {
+							return (
+								item.trackerId == Number(trackerId) &&
+								array.findIndex(
+									(i) => i.itemId == item.itemId
+								) == index
+							);
+						}).length ?? 0)
 					}
 				/>
 				{importing && (

--- a/editorextensions/codebeamer-custom-ui/src/importmodal.ts
+++ b/editorextensions/codebeamer-custom-ui/src/importmodal.ts
@@ -144,6 +144,10 @@ export class ImportModal extends Modal {
 			this.setCardData(block, cardData);
 			block.setDescription(' '); // Add empty description to disable 'Description' placeholder on created cards
 			block.shapeData.set('codebeamerItemId', cardData.codebeamerItemId);
+			block.shapeData.set(
+				'codebeamerTrackerId',
+				cardData.codebeamerTrackerId
+			);
 		}
 	}
 
@@ -182,6 +186,7 @@ export class ImportModal extends Modal {
 		const data = cardBlocks.map((cardBlock) => ({
 			cardBlock: cardBlock,
 			codebeamerItemId: cardBlock.shapeData.get('codebeamerItemId'),
+			codebeamerTrackerId: cardBlock.shapeData.get('codebeamerTrackerId'),
 		}));
 		this.sendMessage(JSON.stringify(data));
 	}


### PR DESCRIPTION
[//]: # 'This is the default template for Merge Requests'
When I implemented the logic to only display the count for unimported items on the Import All button I did not consider trackers that loaded the items lazily.

When a tracker with a lot of items is opened, the calculation for the count of unimported items uses the length of all items in the tracker **minus** the loaded items which have already been imported. Since not all items have been loaded, the button displays that there are a lot left to import.

To fix this changed from using length of all items to length of loaded items.
The drawback to this solution is the Import All button only is useable for the items that have been loaded in the QueryResults

**Before**:
![before](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark/assets/83122000/1085aa7b-32f0-481c-af81-6a270d9aaddb)

**After**:
![after](https://github.com/codeBeamer-Extensions-and-Addons/codebeamer-lucidspark/assets/83122000/a7be63d7-7b40-4920-824e-d1f775378f11)

### Changes

| File         | Changes                     |
| ------------ | --------------------------- |
| `editorextensions\codebeamer-custom-ui\modal\src\pages\import\components\queryResults\QueryResults.tsx` |Changed from using data?.total to data?.items.length when calculating unImportedItemsCount|


## Checklist

### Assignee

-   [x] Adequate Milestone set :triangular_flag_on_post:  
-   [x] Adequate labels set :label:  
-   [ ] Affected documentation updated :books:
    - [ ] Changelog :bookmark_tabs:
    - [ ] Wiki :blue_book:

### Reviewer

-   [ ] Testing
    -   [ ] Coverage :ok_hand:
    -   [ ] Quality :ok_hand:
    -   [ ] Evergreen :100:
-   [ ] Code Quality
    -   [ ] :zero: new lint errors :poop:  
    -   [ ] Maintainable :tools:
    -   [ ] Good patterns :third_place:
