### PR TITLE
1485512 improve import all button test coverage

### DIFF
--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/importActions/importActions.cy.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/importActions/importActions.cy.tsx
@@ -93,9 +93,9 @@ describe('<ImportActions>', () => {
 			const handler = cy.spy().as('handler');
 
 			const items: CardBlockToItemMapping[] = [
-				{ itemId: 1, cardBlockId: '' },
-				{ itemId: 2, cardBlockId: '' },
-				{ itemId: 3, cardBlockId: '' },
+				{ itemId: 1, trackerId: 1, cardBlockId: '' },
+				{ itemId: 2, trackerId: 1, cardBlockId: '' },
+				{ itemId: 3, trackerId: 1, cardBlockId: '' },
 			];
 
 			cy.mount(
@@ -118,9 +118,9 @@ describe('<ImportActions>', () => {
 		context('syncing', () => {
 			it('displays the amount of already imported Items on the Sync button', () => {
 				const items: CardBlockToItemMapping[] = [
-					{ itemId: 1, cardBlockId: '' },
-					{ itemId: 2, cardBlockId: '' },
-					{ itemId: 3, cardBlockId: '' },
+					{ itemId: 1, trackerId: 1, cardBlockId: '' },
+					{ itemId: 2, trackerId: 1, cardBlockId: '' },
+					{ itemId: 3, trackerId: 1, cardBlockId: '' },
 				];
 
 				cy.mount(
@@ -142,9 +142,9 @@ describe('<ImportActions>', () => {
 				const handler = cy.spy().as('handler');
 
 				const items: CardBlockToItemMapping[] = [
-					{ itemId: 1, cardBlockId: '' },
-					{ itemId: 2, cardBlockId: '' },
-					{ itemId: 3, cardBlockId: '' },
+					{ itemId: 1, trackerId: 1, cardBlockId: '' },
+					{ itemId: 2, trackerId: 1, cardBlockId: '' },
+					{ itemId: 3, trackerId: 1, cardBlockId: '' },
 				];
 
 				cy.mount(

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/queryResults.cy.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/queryResults.cy.tsx
@@ -6,6 +6,8 @@ import {
 } from '../../../../store/slices/userSettingsSlice';
 import { getStore } from '../../../../store/store';
 import QueryResults from './QueryResults';
+import query_multi_page from '../../../../../cypress/fixtures/query_multi-page.json';
+import query_multi_page_2 from '../../../../../cypress/fixtures/query_multi-page_2.json';
 
 describe('<QueryResults>', () => {
 	it('mounts', () => {
@@ -214,7 +216,21 @@ describe('<QueryResults>', () => {
 
 		cy.mountWithStore(<QueryResults />, { reduxStore: store });
 
-		cy.getBySel('importAll').should('have.text', 'Import all (11)');
+		const expectedCount = query_multi_page.items
+			.concat(query_multi_page_2.items)
+			.filter(
+				(item) =>
+					mockImportedItems.filter(
+						(importedItem) =>
+							importedItem.codebeamerItemId === item.id &&
+							importedItem.codebeamerTrackerId === item.tracker.id
+					).length === 0
+			).length;
+
+		cy.getBySel('importAll').should(
+			'have.text',
+			`Import all (${expectedCount})`
+		);
 	});
 
 	describe('lazy loading', () => {

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/queryResults.cy.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/queryResults.cy.tsx
@@ -131,6 +131,92 @@ describe('<QueryResults>', () => {
 			.should('equal', expectedQueryString);
 	});
 
+	it('passes the count of tracker items that have not been imported yet to the Import All button', () => {
+		const mockImportedItems = [
+			{
+				cardBlock: { id: '1' },
+				codebeamerItemId: 1,
+				codebeamerTrackerId: 4877085,
+			},
+			{
+				cardBlock: { id: '2' },
+				codebeamerItemId: 2,
+				codebeamerTrackerId: 4877085,
+			},
+			{
+				cardBlock: { id: '3' },
+				codebeamerItemId: 3,
+				codebeamerTrackerId: 4877085,
+			},
+			{
+				cardBlock: { id: '4' },
+				codebeamerItemId: 4,
+				codebeamerTrackerId: 4877085,
+			},
+
+			// items from a different tracker
+			{
+				cardBlock: { id: '5' },
+				codebeamerItemId: 5,
+				codebeamerTrackerId: 999,
+			},
+			{
+				cardBlock: { id: '6' },
+				codebeamerItemId: 6,
+				codebeamerTrackerId: 999,
+			},
+			{
+				cardBlock: { id: '7' },
+				codebeamerItemId: 7,
+				codebeamerTrackerId: 999,
+			},
+			{
+				cardBlock: { id: '8' },
+				codebeamerItemId: 8,
+				codebeamerTrackerId: 999,
+			},
+
+			// duplicate items
+			{
+				cardBlock: { id: '9' },
+				codebeamerItemId: 1,
+				codebeamerTrackerId: 4877085,
+			},
+			{
+				cardBlock: { id: '10' },
+				codebeamerItemId: 2,
+				codebeamerTrackerId: 4877085,
+			},
+			{
+				cardBlock: { id: '11' },
+				codebeamerItemId: 3,
+				codebeamerTrackerId: 4877085,
+			},
+			{
+				cardBlock: { id: '12' },
+				codebeamerItemId: 4,
+				codebeamerTrackerId: 4877085,
+			},
+		];
+
+		cy.stub(window.parent, 'postMessage')
+			.as('boardGetStub')
+			.callsFake(() => {
+				window.postMessage(JSON.stringify(mockImportedItems), '*');
+			});
+
+		const store = getStore();
+		store.dispatch(setTrackerId('4877085'));
+
+		cy.intercept('POST', `**/api/v3/items/query`, {
+			fixture: 'query_multi-page.json',
+		}).as('itemQuery');
+
+		cy.mountWithStore(<QueryResults />, { reduxStore: store });
+
+		cy.getBySel('importAll').should('have.text', 'Import all (11)');
+	});
+
 	describe('lazy loading', () => {
 		beforeEach(() => {
 			const store = getStore();

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/updater/updater.cy.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/updater/updater.cy.tsx
@@ -33,9 +33,9 @@ describe('<Updater>', () => {
 
 	it('fetches the details of the items passed as props', () => {
 		const items: CardBlockToItemMapping[] = [
-			{ itemId: 1, cardBlockId: '' },
-			{ itemId: 2, cardBlockId: '' },
-			{ itemId: 3, cardBlockId: '' },
+			{ itemId: 1, trackerId: 1, cardBlockId: '' },
+			{ itemId: 2, trackerId: 1, cardBlockId: '' },
+			{ itemId: 3, trackerId: 1, cardBlockId: '' },
 		];
 		const store = getStore();
 
@@ -55,9 +55,9 @@ describe('<Updater>', () => {
 
 		it('shows the total amount of items to import based on the passed items array', () => {
 			const items: CardBlockToItemMapping[] = [
-				{ itemId: 1, cardBlockId: '' },
-				{ itemId: 2, cardBlockId: '' },
-				{ itemId: 3, cardBlockId: '' },
+				{ itemId: 1, trackerId: 1, cardBlockId: '' },
+				{ itemId: 2, trackerId: 1, cardBlockId: '' },
+				{ itemId: 3, trackerId: 1, cardBlockId: '' },
 			];
 			cy.intercept('POST', '**/api/v3/items/query').as('fetch');
 


### PR DESCRIPTION
[//]: # 'This is the default template for Merge Requests'

## Test description

**As** a User  
**I want to** use the plugin bug free  
**So that** I can work more efficiently 

### Important
I placed the test inside the queryResults.cy.tsx since the calculation I'm testing, is being done inside QueryResults.tsx and then that result is passed as a property to ImportActions.tsx.
Let me know if this is okay.

### Changes

| File         | Changes                     |
| ------------ | --------------------------- |
| `editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/queryResults/queryResults.cy.tsx` |Added a test to make sure the calculation of unimportedItems is correct|
|`editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/importActions/importActions.cy.tsx`|Added the trackerId property to item arrays since I added that property to the CardBlockToItemMapping interface in the [fix Import all button task](https://retina.roche.com/cb/issue/1457451)|
|`editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/updater/updater.cy.tsx`|Same as the change above|

## Testing approach

[//]: # 'Describe how the functionality is / can be tested'
[//]: # 'If there are unit tests, describe them'

**Scenario**: Have items from different trackers on the lucidspark board  
**Given** I open the import modal
**When** I select a tracker
**Then** I see the amount of items from the tracker that have not been imported yet displayed on the Import All button

**Scenario**: Have duplicate items on the lucidspark board  
**Given** I open the import modal
**When** I select a tracker
**Then** I see the amount of items from the tracker that have not been imported yet displayed on the Import All button

## Checklist

### Assignee

-   [x] Adequate Milestone set :triangular_flag_on_post:  
-   [x] Adequate labels set :label:  
-   [ ] Affected documentation updated :books:
    - [ ] Changelog :bookmark_tabs:
    - [ ] Wiki :blue_book:

### Reviewer

-   [ ] Testing
    -   [ ] Coverage :ok_hand:
    -   [ ] Quality :ok_hand:
    -   [ ] Evergreen :100:
-   [ ] Code Quality
    -   [ ] :zero: new lint errors :poop:  
    -   [ ] Maintainable :tools:
    -   [ ] Good patterns :third_place:
