### PR TITLE
fixed the cbql- input and toggle default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### [1.2.0]
+
+#### Added
+
+#### Changed
+
+-   Fixed the issue where the Assisted query input was not used as the default query input
+
 ## Released
 
 ### [1.1.0]

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/Query.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/Query.tsx
@@ -17,6 +17,10 @@ export default function Query() {
 	return (
 		<div className="flex-row align-items-center">
 			{advancedSearch ? (
+				<div className="w-100">
+					<CbqlInput />
+				</div>
+			) : (
 				<div className="grid fade-in-quick">
 					<div className="cs1 ce3">
 						<TrackerSelect />
@@ -27,10 +31,6 @@ export default function Query() {
 					<div className="cs8 ce12 text-center active-filters-container">
 						<ActiveFilters />
 					</div>
-				</div>
-			) : (
-				<div className="w-100">
-					<CbqlInput />
 				</div>
 			)}
 			<CbqlToggle />

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/cbqlToggle/CbqlToggle.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/cbqlToggle/CbqlToggle.tsx
@@ -19,7 +19,7 @@ export default function CbqlToggle() {
 			<div className="ml-1" />
 			<div className="mt-1 mr-1 soft-border-left" />
 			<DefaultOverlayTrigger
-				content={advancedSearch ? 'CBQL Input' : 'Assisted Query'}
+				content={advancedSearch ? 'Assisted Query' : 'CBQL Input'}
 			>
 				<button
 					className={'mx-1 mt-1 button button-secondary button-small'}
@@ -27,6 +27,11 @@ export default function CbqlToggle() {
 					data-test="search-method"
 				>
 					{advancedSearch ? (
+						<span
+							data-test="icon-parameters"
+							className="icon icon-parameters clickable"
+						></span>
+					) : (
 						<i data-test="cbql-icon">
 							<svg
 								width="24"
@@ -45,11 +50,6 @@ export default function CbqlToggle() {
 								</text>
 							</svg>
 						</i>
-					) : (
-						<span
-							data-test="icon-parameters"
-							className="icon icon-parameters clickable"
-						></span>
 					)}
 				</button>
 			</DefaultOverlayTrigger>

--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/cbqlToggle/cbqlToggle.cy.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/cbqlToggle/cbqlToggle.cy.tsx
@@ -12,29 +12,29 @@ describe('<CbqlToggle>', () => {
 		cy.mountWithStore(<CbqlToggle />);
 	});
 
-	it('displays the "Query Assistant" button by default', () => {
+	it('displays the "CBQL" button by default', () => {
 		cy.mountWithStore(<CbqlToggle />);
 
-		cy.getBySel(queryAssistant).should('exist');
+		cy.getBySel(cbqlIconSelector).should('exist');
 	});
 
 	describe('with cached setting', () => {
-		it('displays "CBQL" when "Advanced Search" is enabled in cache', () => {
+		it('displays "Query Assistant" when "Advanced Search" is enabled in cache', () => {
 			const store = getStore();
 			store.dispatch(setAdvancedSearch(true));
 
 			cy.mountWithStore(<CbqlToggle />, { reduxStore: store });
 
-			cy.getBySel(cbqlIconSelector).should('exist');
+			cy.getBySel(queryAssistant).should('exist');
 		});
 
-		it('displays "Query Assistant" when "Advanced Search" is disabled in cache', () => {
+		it('displays "CBQL" when "Advanced Search" is disabled in cache', () => {
 			const store = getStore();
 			store.dispatch(setAdvancedSearch(false));
 
 			cy.mountWithStore(<CbqlToggle />, { reduxStore: store });
 
-			cy.getBySel(queryAssistant).should('exist');
+			cy.getBySel(cbqlIconSelector).should('exist');
 		});
 	});
 


### PR DESCRIPTION
[//]: # 'This is the default template for Merge Requests'

## Feature description

**As** an end-user  
**I want to** see the assisted query when I first open the import modal 
**So that** I will have an user friendlier time querying codebeamer items

[//]: # 'Describe how the feature was implemented.'
[//]: # 'Describe new views, workflow actions or logic in relation to the User Story.'
[//]: # 'If the change is technical only, specify how you improved our solution.'

### Changes

| File         | Changes                     |
| ------------ | --------------------------- |
| `editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/Query.tsx` | Reversed order of inputs |
| `editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/cbqlToggle/CbqlToggle.tsx` | Reversed order of toggle buttons|
| `editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/query/cbqlToggle/cbqlToggle.cy.tsx` | Corrected tests |


## Testing approach

[//]: # 'Describe how the functionality is / can be tested'
[//]: # 'If there are unit tests, describe them'

**Scenario**: Default Query Input
**Given** I delete the ADVANCED_SEARCH_ENABLED value in the local storage
**When** I open the import modal
**Then** I see the assisted query input

## How do you feel about this MR?

glad I spotted the issue, but next time I will be more careful with testing.

## Checklist

### Assignee

-   [x] Adequate Milestone set :triangular_flag_on_post:  
-   [x] Adequate labels set :label:  
-   [ ] Affected documentation updated :books:
    - [x] Changelog :bookmark_tabs:
    - [ ] Wiki :blue_book:

### Reviewer

-   [ ] Testing
    -   [ ] Coverage :ok_hand:
    -   [ ] Quality :ok_hand:
    -   [ ] Evergreen :100:
-   [ ] Code Quality
    -   [ ] :zero: new lint errors :poop:  
    -   [ ] Maintainable :tools:
    -   [ ] Good patterns :third_place:
