### PR TITLE
fixed importer query string bug

### DIFF
--- a/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/importer/Importer.tsx
+++ b/editorextensions/codebeamer-custom-ui/modal/src/pages/import/components/importer/Importer.tsx
@@ -36,7 +36,7 @@ export default function Importer(props: {
 		const selectedItemsFilter = props.items.length
 			? ` AND item.id IN (${props.items.join(',')})`
 			: '';
-		const importedItemsFilter = props.importedItems
+		const importedItemsFilter = props.importedItems?.length
 			? ` AND item.id NOT IN (${props.importedItems
 					.map((i) => i.codebeamerItemId)
 					.join(',')})`

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "08f8f5fc-87a9-4f1f-a0bb-f632ffbbdf49",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"extensions": [
 		{
 			"name": "codebeamer-custom-ui",


### PR DESCRIPTION
in the importer, importedItems was changed to be a prop. When Creating the query string the props.importedItems would return true even if it was empty so I had to change it to props.importedItems?.length.

This made it that you couldn't import items on an empty board so I will have to hotfix it into the new 1.2.0 release